### PR TITLE
Add HttpWatcherWebSocketHandler.check_origin

### DIFF
--- a/httpwatcher/server.py
+++ b/httpwatcher/server.py
@@ -375,3 +375,6 @@ class HttpWatcherWebSocketHandler(tornado.websocket.WebSocketHandler):
 
     def on_message(self, message):
         logger.debug("Ignoring message from WebSocket client: %s", message)
+
+    def check_origin(self, origin):
+        return True


### PR DESCRIPTION
To prevent tornado 403 GET warnings when opening websockets

Added the check_origin function to the HttpWatcherWebSocketHandler class.

See these links for references on this -
https://stackoverflow.com/questions/7749914/add-method-to-loaded-class-module-in-python
https://www.tornadoweb.org/en/stable/websocket.html
https://stackoverflow.com/questions/24851207/tornado-403-get-warning-when-opening-websocket